### PR TITLE
Bugfix/issue 18/badly rendered badges containing double quotes

### DIFF
--- a/services/credly.py
+++ b/services/credly.py
@@ -1,7 +1,13 @@
 from bs4 import BeautifulSoup
 import lxml, requests
 
-from settings import CREDLY_SORT, CREDLY_USER, CREDLY_BASE_URL, BADGE_SIZE, NUMBER_LAST_BADGES
+from settings import (
+    CREDLY_SORT,
+    CREDLY_USER,
+    CREDLY_BASE_URL,
+    BADGE_SIZE,
+    NUMBER_LAST_BADGES,
+)
 
 
 class Credly:
@@ -11,11 +17,12 @@ class Credly:
         self.USER = CREDLY_USER
         self.SORT = CREDLY_SORT
 
+        print(self.BASE_URL, self.USER, self.SORT)
+
     def data_from_html(self):
         if self.FILE:
             with open(self.FILE, "r") as f:
                 return f.read()
-
         url = f"{self.BASE_URL}/users/{self.USER}/badges?sort={self.sort_by()}"
         response = requests.get(url)
 
@@ -30,9 +37,9 @@ class Credly:
             "img", {"class": "cr-standard-grid-item-content__image"}
         )[0]
         return {
-            "title": htmlBadge["title"],
+            "title": str(htmlBadge["title"]).replace('"', '\\"'),
             "href": self.BASE_URL + htmlBadge["href"],
-            "img": img["src"].replace('110x110', f'{BADGE_SIZE}x{BADGE_SIZE}'),
+            "img": img["src"].replace("110x110", f"{BADGE_SIZE}x{BADGE_SIZE}"),
         }
 
     def return_badges_html(self):
@@ -43,10 +50,19 @@ class Credly:
     def generate_md_format(self, badges):
         if not badges:
             return None
-        return "\n".join(map(lambda it: f"[![{it['title']}]({it['img']})]({it['href']} \"{it['title']}\")", badges))
+        return "\n".join(
+            map(
+                lambda it: f"[![{it['title']}]({it['img']})]({it['href']} \"{it['title']}\")",
+                badges,
+            )
+        )
 
     def get_markdown(self):
-        badges_html = self.return_badges_html()[0:NUMBER_LAST_BADGES] if NUMBER_LAST_BADGES > 0 else self.return_badges_html()
+        badges_html = (
+            self.return_badges_html()[0:NUMBER_LAST_BADGES]
+            if NUMBER_LAST_BADGES > 0
+            else self.return_badges_html()
+        )
         return self.generate_md_format(
             [self.convert_to_dict(badge) for badge in badges_html]
         )

--- a/settings.py
+++ b/settings.py
@@ -10,12 +10,12 @@ COMMIT_MESSAGE = os.getenv("INPUT_COMMIT_MESSAGE")
 CREDLY_USER = os.getenv("INPUT_CREDLY_USER")
 CREDLY_SORT = os.getenv("INPUT_CREDLY_SORT")
 
-BADGE_SIZE = os.getenv("INPUT_BADGE_SIZE", '110')
+BADGE_SIZE = os.getenv("INPUT_BADGE_SIZE", "110")
 try:
     NUMBER_LAST_BADGES = int(os.getenv("INPUT_NUMBER_LAST_BADGES"))
 except:
     NUMBER_LAST_BADGES = 0
 
-CREDLY_BASE_URL= "http://www.credly.com"
+CREDLY_BASE_URL = "http://www.credly.com"
 
 LIST_REGEX = f"{START_COMMENT}[\\s\\S]+{END_COMMENT}"


### PR DESCRIPTION
Changes Made:
- Updated code to handle double quotes in badge titles from the https://www.credly.com/ website.
- Fixed rendering issue in the GitHub profile README file.

Related Issue:
Fix for issue #18 

Badges are now displayed correctly even if there are double quotes in the title

Before:
![image](https://github.com/pemtajo/badge-readme/assets/75540124/0fb13731-1b89-480e-8071-6a4df936e6d8)

After:
![image](https://github.com/pemtajo/badge-readme/assets/75540124/e19eacf5-7274-477e-9a49-a21f571c3ced)

Fix:
[This is the main fix](https://github.com/pemtajo/badge-readme/commit/81f2171eca9567a17e727ff790030f3d5b88dbd0#diff-2dd36c9449fb22ad243cb822d477153f04a472de769bbe47eaa089a5db0bc261R40)