### PR TITLE
Fix: Badge readme generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     unzip \
     gnupg2 \
-    software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory

--- a/setup_chrome.sh
+++ b/setup_chrome.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
-
-# Docker-specific setup script for Chrome and ChromeDriver
-# This script is optimized for container environments
+set -e
 
 echo "Setting up Chrome and ChromeDriver for Docker environment..."
 
 # Update package list
 apt-get update
 
-# Install dependencies
-apt-get install -y wget curl unzip gnupg2 software-properties-common
+# Install dependencies for Chrome
+apt-get install -y wget curl unzip gnupg2 ca-certificates
 
-# Install Google Chrome
+# Install Google Chrome (Debian method)
 if ! command -v google-chrome &> /dev/null; then
     echo "Installing Google Chrome..."
-    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    wget -q -O /usr/share/keyrings/google-linux-signing-key.gpg https://dl.google.com/linux/linux_signing_key.pub
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-key.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google-chrome.list
     apt-get update
     apt-get install -y google-chrome-stable
 else
@@ -26,7 +25,6 @@ fi
 CHROME_VERSION=$(google-chrome --version)
 echo "Chrome version: $CHROME_VERSION"
 
-
 # Install webdriver-manager
 echo "Installing webdriver-manager..."
 pip3 install webdriver-manager
@@ -36,4 +34,4 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 echo "Docker setup complete!"
-echo "ChromeDriver will be managed by webdriver-manager" 
+echo "ChromeDriver will be managed by webdriver-manager"


### PR DESCRIPTION
The badge generation workflow stopped working. The error it returns was:
```
Unable to locate package software-properties-common
  ------
  Dockerfile:8
  --------------------
     7 |     # Install system dependencies
     8 | >>> RUN apt-get update && apt-get install -y \
     9 | >>>     wget \
    10 | >>>     curl \
    11 | >>>     unzip \
    12 | >>>     gnupg2 \
    13 | >>>     software-properties-common \
    14 | >>>     && rm -rf /var/lib/apt/lists/*
    15 |     
  --------------------
  ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y     wget     curl     unzip     gnupg2     software-properties-common     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```
The issue probably stems from an update to the source Debian image. To fix the issue I propose to remove the software-properties-common which Debian no longer provides and rewrite setup_chrome.sh to install chrome in a different way.