### PR TITLE
fix: switch back to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.23
+FROM python:3.14.2-slim-trixie
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Fixes #34 

Switches to slim-trixie (which is identical to slim but more explicit about version)

Tested I could build the Dockerfile afterwards with `docker build .`