### PR TITLE
Use Markdown image syntax to restore the horizontal badge layout

### DIFF
--- a/credly.py
+++ b/credly.py
@@ -172,7 +172,7 @@ class Credly:
                     issue_date = date_match.group(1)
         
         img_src = img.get("src", "")
-        img_src = img_src.replace("https://images.credly.com/", "https://images.credly.com/size/80x80/")
+        img_src = img_src.replace("https://images.credly.com/", "https://images.credly.com/size/340x100/")
         
         href = ""
         # Try to find the div with role="button" that contains the href
@@ -279,10 +279,9 @@ class Credly:
         if not valid_badges:
             return None
             
-        # Use HTML img tags with explicit size instead of markdown image syntax
         return "\n".join(
             map(
-                lambda it: f'<a href="{it["href"]}" title="{it["title"]}"><img src="{it["img"]}" alt="{it["title"]}" width="80" height="80"></a>',
+                lambda it: f'[![{it["title"]}]({it["img"]})]({it["href"]})',
                 valid_badges,
             )
         )

--- a/credly.py
+++ b/credly.py
@@ -172,7 +172,7 @@ class Credly:
                     issue_date = date_match.group(1)
         
         img_src = img.get("src", "")
-        img_src = img_src.replace("https://images.credly.com/", "https://images.credly.com/size/340x100/")
+        img_src = img_src.replace("https://images.credly.com/", "https://images.credly.com/size/80x80/")
         
         href = ""
         # Try to find the div with role="button" that contains the href


### PR DESCRIPTION
## Problem

Badges were displayed vertically in the README instead of horizontally. 
This appeared to be caused by using `<a>` HTML tags, which GitHub renders 
as block-level elements, forcing each badge onto its own line.

## Solution

Changed the output format from HTML `<img>` tags to standard Markdown image 
link syntax (`[![alt](img)](href)`). GitHub renders inline Markdown images 
horizontally, restoring the expected side-by-side badge layout.

## Changes

- Replace `<a><img></a>` HTML output with `[![title](img)](href)` Markdown syntax

## Before / After
<img width="548" height="518" alt="スクリーンショット 2026-04-20 14 21 46" src="https://github.com/user-attachments/assets/6fedcc8f-f488-4058-b865-f19db4231066" />
<img width="651" height="146" alt="スクリーンショット 2026-04-20 14 21 56" src="https://github.com/user-attachments/assets/b764f146-cbb9-4a66-9d36-d2484ba635d2" />
